### PR TITLE
Change is to isA

### DIFF
--- a/test/org/mockito/internal/runners/RunnerFactoryTest.java
+++ b/test/org/mockito/internal/runners/RunnerFactoryTest.java
@@ -37,7 +37,7 @@ public class RunnerFactoryTest extends TestBase {
         RunnerImpl runner = factory.create(RunnerFactoryTest.class);
         
         //then
-        assertThat(runner, is(JUnit44RunnerImpl.class));
+        assertThat(runner, isA(JUnit44RunnerImpl.class));
     }
     
     @Test
@@ -54,7 +54,7 @@ public class RunnerFactoryTest extends TestBase {
         RunnerImpl runner = factory.create(RunnerFactoryTest.class);
         
         //then
-        assertThat(runner, is(JUnit45AndHigherRunnerImpl.class));
+        assertThat(runner, isA(JUnit45AndHigherRunnerImpl.class));
     }
     
     @Test

--- a/test/org/mockitousage/basicapi/MocksCreationTest.java
+++ b/test/org/mockitousage/basicapi/MocksCreationTest.java
@@ -62,7 +62,7 @@ public class MocksCreationTest extends TestBase {
         //then
         assertContains("great mockie", name);
         //and
-        assertThat(mock, is(List.class));
+        assertThat(mock, isA(List.class));
     }
     
     @Test

--- a/test/org/mockitoutil/ExtraMatchers.java
+++ b/test/org/mockitoutil/ExtraMatchers.java
@@ -134,7 +134,7 @@ public class ExtraMatchers {
     }
     
     public static org.hamcrest.Matcher<java.lang.Object> clazz(java.lang.Class<?> type) {
-        return CoreMatchers.is(type);
+        return CoreMatchers.is(CoreMatchers.instanceOf(type));
     }
 
     public static Assertor hasMethodsInStackTrace(final String ... methods) {

--- a/test/org/mockitoutil/ExtraMatchers.java
+++ b/test/org/mockitoutil/ExtraMatchers.java
@@ -134,7 +134,7 @@ public class ExtraMatchers {
     }
     
     public static org.hamcrest.Matcher<java.lang.Object> clazz(java.lang.Class<?> type) {
-        return CoreMatchers.is(CoreMatchers.instanceOf(type));
+        return CoreMatchers.isA(type);
     }
 
     public static Assertor hasMethodsInStackTrace(final String ... methods) {


### PR DESCRIPTION
Hamcrest 1.3 removed `is(Class<T>)` and replaced it with `isA(Class<T>)`. This pull fixes the tests that stopped compiling.
